### PR TITLE
PLF-6676 : lower top navigation bar z-index to show the document preview close icon

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/ecms/skin/UIDocumentPreview/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/ecms/skin/UIDocumentPreview/Style.less
@@ -10,11 +10,12 @@
 	color: @textColor;
 	.uiDocumentPreview {
 		padding-left: 30px;
-		padding-top: 50px;
+		padding-top: 35px;
 		.exitWindow .uiIconClose { 
 			position: absolute;
 			top: 7px;
 			right: 7px;
+		  	cursor: pointer;
 			&:hover {
                 color: @colorIconSecondary!important;
 			}

--- a/platform-ui-skin/src/main/webapp/skin/less/platform/skin/uiToolbarContainer/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/platform/skin/uiToolbarContainer/Style.less
@@ -3,7 +3,7 @@
 	position: fixed;
 	top: 0;
 	width: 100%;
-	z-index: 1001;
+	z-index: 100;
 	.UserInfoPortletTDContainer,
 	.UIHelpPlatformToolbarPortletTDContainer,
 	.SearchPortletTDContainer,


### PR DESCRIPTION
Since the improvement which allowed to have a fixed top navigation bar, the document preview close icon was not visible anymore.
This PR changes the z-index of the top navigation bar to show it back. It allows add the pointer cursor and the close icon and reduce the container of the close icon to remove the useless empty space.