### PR TITLE
PLF-6964 : remove fixed width on activities' images

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
@@ -211,13 +211,6 @@
 	.description {
 		padding: 30px 16px;
 		display: inline-block;
-		
-		img {
-		margin: 0 20px 20px 0;
-		text-align: center;
-		width: 47.2%;
-		}
-		
 	}
 }
 
@@ -506,6 +499,12 @@
 					list-style-type: disc;
 					list-style-position: inside;
 				}
+			}
+		}
+		.description {
+			img {
+				margin: 0 10px 10px 0;
+				text-align: center;
 			}
 		}
 		.description:after {


### PR DESCRIPTION
I removed the fixed width on activities' images, move the style to a common location for all activities and reduce a little bit the padding to make it look nicer.