### PR TITLE
PLF-7230 : do not display grey mask in edit page/layout mode

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/_responsive.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/_responsive.less
@@ -325,6 +325,12 @@
         z-index: 99999!important;
     }
 
+    // do not display grey mask in edit page/layout mode
+    .UIEditInlineWS .uiPopupWrapper {
+        position: relative;
+        overflow: initial;
+    }
+
     .wiki-body {
         .uiPopupWrapper {
             .uiPopup {


### PR DESCRIPTION
With screens smaller than 1024px, a grey mask is used when a popup is displayed. In the edit page/layout page, the applications catalog is a popup (in term of WebUI component), so the grey mask is displayed, which avoids to drag and drop applications and containers.
This PR prevents the grey mask to be displayed in the edit page/layout page.