### PR TITLE
SOC-5947 : remove width length for notifications display

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/portlets/uiIntranetNotification/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/portlets/uiIntranetNotification/Style.less
@@ -78,7 +78,6 @@
         overflow: hidden;
       }
       .comment, .commentNoHtml, .readmore {
-        max-width: 400px;
         padding-left: 20px;
         font-style: italic;
        }      


### PR DESCRIPTION
The width of the container of the notifications contents in the View All Notifications page is limited (400px). I don't see a valid reason for the limitation. I removed it.