### PR TITLE
MOB-2084 link's popup disappears when clicking in text field to show …

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
@@ -2196,6 +2196,9 @@ blockquote:after {
 
 // Composer simpleLink dialog
 .simpleLinkDialog {
+    > .cke_dialog {
+        position: fixed!important;
+    }
     textarea, input[type="text"] {
         width: 100%;
     }


### PR DESCRIPTION
the ckeditor dialog position change form fixed to absolute when the dialogue height is bigger than viewport height, so I add the !important to avoid this change.