### PR TITLE
Fix/mob 2194: Make the Login User icon and Password icon display in the right position

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/extensions/login.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/extensions/login.less
@@ -383,11 +383,11 @@ input::-ms-clear,input[type=password]::-ms-reveal{
 			url("@{images-path}/platform/portlets/extensions/loginCenterBGXs.png") repeat-x bottom;
 			background-color: @baseBackground;
 			.loginContent {
-			    .userCredentials{
+			    .userCredentials {
 			        .iconUser, .iconPswrd {
-                        top: 5px;
-                        bottom: 6px;
-                    }
+			            top: 5px;
+			            bottom: 6px;
+			        }
 			    }
 				input {
 					width: 172px;

--- a/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/extensions/login.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/extensions/login.less
@@ -91,8 +91,8 @@ body {
 				position: absolute;
 				width: 40px;
 				left: 1px;
-				top: 1px;
-				bottom: 15px;
+				top: 4px;
+				bottom: 6px;
 			}
 		}
 		input {

--- a/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/extensions/login.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/extensions/login.less
@@ -383,10 +383,10 @@ input::-ms-clear,input[type=password]::-ms-reveal{
 			url("@{images-path}/platform/portlets/extensions/loginCenterBGXs.png") repeat-x bottom;
 			background-color: @baseBackground;
 			.loginContent {
-			    .iconUser, .iconPswrd {
-			        top: 5px;
-			        bottom: 6px;
-			    }
+			    	.iconUser, .iconPswrd {
+			        	top: 5px;
+			        	bottom: 6px;
+			    	}
 				input {
 					width: 172px;
 					background-position: left -5px;

--- a/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/extensions/login.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/extensions/login.less
@@ -383,10 +383,10 @@ input::-ms-clear,input[type=password]::-ms-reveal{
 			url("@{images-path}/platform/portlets/extensions/loginCenterBGXs.png") repeat-x bottom;
 			background-color: @baseBackground;
 			.loginContent {
-			        .iconUser, .iconPswrd {
-			            top: 5px;
-			            bottom: 6px;
-			        }
+			    .iconUser, .iconPswrd {
+			        top: 5px;
+			        bottom: 6px;
+			    }
 				input {
 					width: 172px;
 					background-position: left -5px;

--- a/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/extensions/login.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/extensions/login.less
@@ -383,12 +383,10 @@ input::-ms-clear,input[type=password]::-ms-reveal{
 			url("@{images-path}/platform/portlets/extensions/loginCenterBGXs.png") repeat-x bottom;
 			background-color: @baseBackground;
 			.loginContent {
-			    .userCredentials {
 			        .iconUser, .iconPswrd {
 			            top: 5px;
 			            bottom: 6px;
 			        }
-			    }
 				input {
 					width: 172px;
 					background-position: left -5px;

--- a/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/extensions/login.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/extensions/login.less
@@ -91,8 +91,19 @@ body {
 				position: absolute;
 				width: 40px;
 				left: 1px;
-				top: 4px;
-				bottom: 6px;
+				top: 1px;
+				bottom: 15px;
+			}
+			@media (max-width: 480px){
+			.iconUser, .iconPswrd {
+            				border-right: solid 1px @inputBorder;
+            				border-radius: 4px 0 0 4px;
+            				position: absolute;
+            				width: 40px;
+            				left: 1px;
+            				top: 5px;
+            				bottom: 6px;
+            			}
 			}
 		}
 		input {

--- a/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/extensions/login.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/extensions/login.less
@@ -94,17 +94,6 @@ body {
 				top: 1px;
 				bottom: 15px;
 			}
-			@media (max-width: 480px){
-			.iconUser, .iconPswrd {
-            				border-right: solid 1px @inputBorder;
-            				border-radius: 4px 0 0 4px;
-            				position: absolute;
-            				width: 40px;
-            				left: 1px;
-            				top: 5px;
-            				bottom: 6px;
-            			}
-			}
 		}
 		input {
 			width: 260px;
@@ -394,6 +383,12 @@ input::-ms-clear,input[type=password]::-ms-reveal{
 			url("@{images-path}/platform/portlets/extensions/loginCenterBGXs.png") repeat-x bottom;
 			background-color: @baseBackground;
 			.loginContent {
+			    .userCredentials{
+			        .iconUser, .iconPswrd {
+                        top: 5px;
+                        bottom: 6px;
+                    }
+			    }
 				input {
 					width: 172px;
 					background-position: left -5px;


### PR DESCRIPTION
When the login page is loaded the User and Password icons aren't well displayed in mobile view-port, i found that the .iconUser and .iconPswrd css properties differs from desktop view-port and mobile view-port. So i added responsive properties in order to resolve this gap in terms of pixels.
This fix make the User and Password icons well displayed in both mobile and desktop view-ports.

Tested on platform-5.2.x-edit-activities-comments-SNAPSHOT.