### PR TITLE
fix/ECMS-7887: display well the new content interface after maximizing

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/ecms/portlets/explorer/ecms-explorer.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/ecms/portlets/explorer/ecms-explorer.less
@@ -32,9 +32,6 @@
     .UIDocumentWorkspace .FileContent .Content .FlashViewer {
 		text-align: center;
 	}
-	.uiWorkingArea .rightContainer {
-         z-index: 0;
-    }
 }
 
 .uiActionBar {


### PR DESCRIPTION
When maximizing the interface of adding a new content, the top bar is still shown because of the `z-index = 0` given to the right container. So in order to well display the maximizing, we should delete the z-index.

Tested on : platform-5.2.x